### PR TITLE
Fix flaky GL tests, prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.3.0 - Showcase demo, cross-platform CI, test reliability
 - Add `cmd/examples/showcase`: fullscreen raymarched scene driven by a single fragment shader, with `-screenshot` flag for headless PNG capture
 - Add `shaders/fragment/raymarch_showcase.frag` and `shaders/vertex/fullscreen_triangle.vert` (no-VBO fullscreen triangle)
 - README now embeds a screenshot rendered headlessly from the showcase example
@@ -8,12 +8,7 @@
 - Replace deprecated `gl.PtrOffset` calls with the `WithOffset` overloads in `pkg/resource/vertex_array.go` and the basic/compute examples
 - Drop unused log-buffer `sync.Pool` in `pkg/shader` (triggered SA6002) in favor of a small per-call helper
 - Add package doc comments to `pkg/pipeline` and `pkg/resource`
-
-Known issue (pre-existing, not introduced here): the buffer/texture tests
-under `tests/unit/resource/` occasionally fail under llvmpipe with
-"failed to generate buffer". Reproducible on `main` too; appears to be a
-GL-context-thread-affinity issue in the test harness. Tracked for a
-follow-up.
+- Fix flaky GL tests: Go's test runner schedules individual tests on a different OS thread than `TestMain`; the GL context was stuck on the `TestMain` thread. Each test now acquires/releases the context via a `glSetup(t)` helper that calls `runtime.LockOSThread` + `MakeContextCurrent` and cleans up with `DetachCurrentContext` + `UnlockOSThread`
 
 ## v0.2.0 - Project cleanup and CI fixes
 - Rewrite README to accurately reflect implemented features

--- a/tests/unit/pipeline/pipeline_test.go
+++ b/tests/unit/pipeline/pipeline_test.go
@@ -2,6 +2,7 @@ package pipeline_test
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/go-gl/gl/v4.1-core/gl"
@@ -13,20 +14,19 @@ import (
 var testWindow *glfw.Window
 
 func TestMain(m *testing.M) {
-	// Initialize GLFW
+	runtime.LockOSThread()
+
 	if err := glfw.Init(); err != nil {
 		panic("Failed to initialize GLFW: " + err.Error())
 	}
 	defer glfw.Terminate()
 
-	// Configure OpenGL context
 	glfw.WindowHint(glfw.ContextVersionMajor, 4)
 	glfw.WindowHint(glfw.ContextVersionMinor, 1)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
 	glfw.WindowHint(glfw.Visible, glfw.False)
 
-	// Create window
 	var err error
 	testWindow, err = glfw.CreateWindow(100, 100, "Test", nil, nil)
 	if err != nil {
@@ -34,16 +34,26 @@ func TestMain(m *testing.M) {
 	}
 	defer testWindow.Destroy()
 
-	// Make context current
 	testWindow.MakeContextCurrent()
 
-	// Initialize OpenGL
 	if err := gl.Init(); err != nil {
 		panic("Failed to initialize OpenGL: " + err.Error())
 	}
 
-	// Run tests
+	glfw.DetachCurrentContext()
+	runtime.UnlockOSThread()
+
 	os.Exit(m.Run())
+}
+
+func glSetup(t *testing.T) {
+	t.Helper()
+	runtime.LockOSThread()
+	testWindow.MakeContextCurrent()
+	t.Cleanup(func() {
+		glfw.DetachCurrentContext()
+		runtime.UnlockOSThread()
+	})
 }
 
 func TestPipelineCreation(t *testing.T) {
@@ -57,7 +67,6 @@ func TestPipelineCreation(t *testing.T) {
 		t.Fatal("Pipeline state should not be nil")
 	}
 
-	// Check default state
 	if !state.DepthEnabled {
 		t.Error("Depth test should be enabled by default")
 	}
@@ -73,7 +82,7 @@ func TestPipelineCreation(t *testing.T) {
 
 func TestStateBuilder(t *testing.T) {
 	builder := pipeline.NewBuilder()
-	
+
 	state := builder.
 		WithBlending(true, pipeline.BlendSrcAlpha, pipeline.BlendOneMinusSrcAlpha).
 		WithDepthTest(true, true, pipeline.DepthLess).
@@ -105,20 +114,17 @@ func TestStateBuilder(t *testing.T) {
 }
 
 func TestStateValidation(t *testing.T) {
-	// Test valid state
 	validState := pipeline.DefaultState()
 	if err := validState.Validate(); err != nil {
 		t.Error("Default state should be valid:", err)
 	}
 
-	// Test invalid viewport
 	invalidViewport := pipeline.DefaultState()
 	invalidViewport.ViewportWidth = 0
 	if err := invalidViewport.Validate(); err == nil {
 		t.Error("State with zero viewport width should be invalid")
 	}
 
-	// Test invalid blend function
 	invalidBlend := pipeline.DefaultState()
 	invalidBlend.BlendEnabled = true
 	invalidBlend.BlendSrc = pipeline.BlendZero
@@ -129,43 +135,37 @@ func TestStateValidation(t *testing.T) {
 }
 
 func TestPipelineStateStack(t *testing.T) {
+	glSetup(t)
 	p := pipeline.New()
 
-	// Get initial state
 	initialState := p.GetState()
 	initialDepth := initialState.DepthEnabled
 
-	// Push state
 	p.PushState()
 
-	// Modify current state
 	p.SetDepthTest(false, false, pipeline.DepthAlways)
 
-	// Current state should be modified
 	if p.GetState().DepthEnabled {
 		t.Error("Depth test should be disabled")
 	}
 
-	// Pop state
 	if err := p.PopState(); err != nil {
 		t.Fatal("Failed to pop state:", err)
 	}
 
-	// State should be restored
 	if p.GetState().DepthEnabled != initialDepth {
 		t.Error("State not properly restored after pop")
 	}
 
-	// Pop from empty stack should error
 	if err := p.PopState(); err == nil {
 		t.Error("Popping from empty stack should return error")
 	}
 }
 
 func TestPipelineStateApplication(t *testing.T) {
+	glSetup(t)
 	p := pipeline.New()
 
-	// Create test shaders
 	vertexSource := `#version 410 core
 layout(location = 0) in vec3 aPosition;
 void main() {
@@ -196,28 +196,25 @@ void main() {
 	}
 	defer program.Delete()
 
-	// Create state with program
 	state := pipeline.NewBuilder().
 		WithProgram(program).
 		WithBlending(true, pipeline.BlendSrcAlpha, pipeline.BlendOneMinusSrcAlpha).
 		WithDepthTest(true, true, pipeline.DepthLess).
 		Build()
 
-	// Apply state
 	if err := p.SetState(state); err != nil {
 		t.Fatal("Failed to set pipeline state:", err)
 	}
 
-	// Verify state was applied
 	if p.GetState().Program != program {
 		t.Error("Program not properly set")
 	}
 }
 
 func TestPipelineIndividualSetters(t *testing.T) {
+	glSetup(t)
 	p := pipeline.New()
 
-	// Test SetBlending
 	p.SetBlending(true, pipeline.BlendOne, pipeline.BlendOne)
 	if !p.GetState().BlendEnabled {
 		t.Error("Blending should be enabled")
@@ -226,7 +223,6 @@ func TestPipelineIndividualSetters(t *testing.T) {
 		t.Error("Blend source not set correctly")
 	}
 
-	// Test SetDepthTest
 	p.SetDepthTest(false, false, pipeline.DepthAlways)
 	if p.GetState().DepthEnabled {
 		t.Error("Depth test should be disabled")
@@ -235,13 +231,11 @@ func TestPipelineIndividualSetters(t *testing.T) {
 		t.Error("Depth function not set correctly")
 	}
 
-	// Test SetCulling
 	p.SetCulling(false, pipeline.CullNone)
 	if p.GetState().CullEnabled {
 		t.Error("Culling should be disabled")
 	}
 
-	// Test SetViewport
 	p.SetViewport(10, 20, 640, 480)
 	if p.GetState().ViewportX != 10 || p.GetState().ViewportY != 20 {
 		t.Error("Viewport position not set correctly")
@@ -250,7 +244,6 @@ func TestPipelineIndividualSetters(t *testing.T) {
 		t.Error("Viewport dimensions not set correctly")
 	}
 
-	// Test SetWireframe
 	p.SetWireframe(true)
 	if !p.GetState().WireframeMode {
 		t.Error("Wireframe mode should be enabled")
@@ -258,12 +251,11 @@ func TestPipelineIndividualSetters(t *testing.T) {
 }
 
 func TestPipelineClearOperations(t *testing.T) {
+	glSetup(t)
 	p := pipeline.New()
 
-	// Test SetClearColor (just ensure it doesn't panic)
 	p.SetClearColor(0.1, 0.2, 0.3, 1.0)
 
-	// Test Clear (just ensure it doesn't panic)
 	p.Clear(true, true, false)
 	p.Clear(false, true, true)
 	p.Clear(true, false, true)

--- a/tests/unit/resource/resource_test.go
+++ b/tests/unit/resource/resource_test.go
@@ -2,6 +2,7 @@ package resource_test
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/go-gl/gl/v4.1-core/gl"
@@ -12,20 +13,20 @@ import (
 var testWindow *glfw.Window
 
 func TestMain(m *testing.M) {
-	// Initialize GLFW
+	// GLFW requires init and window creation on a thread-locked goroutine.
+	runtime.LockOSThread()
+
 	if err := glfw.Init(); err != nil {
 		panic("Failed to initialize GLFW: " + err.Error())
 	}
 	defer glfw.Terminate()
 
-	// Configure OpenGL context
 	glfw.WindowHint(glfw.ContextVersionMajor, 4)
 	glfw.WindowHint(glfw.ContextVersionMinor, 1)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
 	glfw.WindowHint(glfw.Visible, glfw.False)
 
-	// Create window
 	var err error
 	testWindow, err = glfw.CreateWindow(100, 100, "Test", nil, nil)
 	if err != nil {
@@ -33,21 +34,36 @@ func TestMain(m *testing.M) {
 	}
 	defer testWindow.Destroy()
 
-	// Make context current
 	testWindow.MakeContextCurrent()
 
-	// Initialize OpenGL
 	if err := gl.Init(); err != nil {
 		panic("Failed to initialize OpenGL: " + err.Error())
 	}
 
-	// Run tests
+	// Release the context so test goroutines — which Go's test runner
+	// may schedule on a different OS thread — can acquire it.
+	glfw.DetachCurrentContext()
+	runtime.UnlockOSThread()
+
 	os.Exit(m.Run())
 }
 
+// glSetup re-acquires the GL context on the current OS thread.
+// Must be called at the start of every test that issues GL calls.
+func glSetup(t *testing.T) {
+	t.Helper()
+	runtime.LockOSThread()
+	testWindow.MakeContextCurrent()
+	t.Cleanup(func() {
+		glfw.DetachCurrentContext()
+		runtime.UnlockOSThread()
+	})
+}
+
 func TestVertexBufferCreation(t *testing.T) {
+	glSetup(t)
 	data := []float32{1.0, 2.0, 3.0, 4.0}
-	
+
 	vbo, err := resource.NewVertexBuffer(data, resource.StaticDraw)
 	if err != nil {
 		t.Fatal("Failed to create vertex buffer:", err)
@@ -68,8 +84,9 @@ func TestVertexBufferCreation(t *testing.T) {
 }
 
 func TestIndexBufferCreation(t *testing.T) {
+	glSetup(t)
 	data := []uint32{0, 1, 2, 3, 4, 5}
-	
+
 	ibo, err := resource.NewIndexBuffer(data, resource.StaticDraw)
 	if err != nil {
 		t.Fatal("Failed to create index buffer:", err)
@@ -90,8 +107,9 @@ func TestIndexBufferCreation(t *testing.T) {
 }
 
 func TestIndexBuffer16Creation(t *testing.T) {
+	glSetup(t)
 	data := []uint16{0, 1, 2, 3}
-	
+
 	ibo, err := resource.NewIndexBuffer16(data, resource.StaticDraw)
 	if err != nil {
 		t.Fatal("Failed to create 16-bit index buffer:", err)
@@ -108,8 +126,9 @@ func TestIndexBuffer16Creation(t *testing.T) {
 }
 
 func TestUniformBufferCreation(t *testing.T) {
-	size := 256 // UBO size
-	
+	glSetup(t)
+	size := 256
+
 	ubo, err := resource.NewUniformBuffer(size, resource.DynamicDraw)
 	if err != nil {
 		t.Fatal("Failed to create uniform buffer:", err)
@@ -130,6 +149,7 @@ func TestUniformBufferCreation(t *testing.T) {
 }
 
 func TestVertexArrayCreation(t *testing.T) {
+	glSetup(t)
 	vao, err := resource.NewVertexArray()
 	if err != nil {
 		t.Fatal("Failed to create vertex array:", err)
@@ -147,9 +167,9 @@ func TestVertexArrayCreation(t *testing.T) {
 
 func TestVertexLayout(t *testing.T) {
 	layout := resource.NewVertexLayout().
-		AddFloat(0, 3).  // Position
-		AddFloat(1, 2).  // UV
-		AddInt(2, 1)     // ID
+		AddFloat(0, 3). // Position
+		AddFloat(1, 2). // UV
+		AddInt(2, 1)    // ID
 
 	if len(layout.Attributes) != 3 {
 		t.Error("Layout should have 3 attributes")
@@ -174,11 +194,12 @@ func TestVertexLayout(t *testing.T) {
 }
 
 func TestMeshCreation(t *testing.T) {
+	glSetup(t)
 	vertices := []float32{
 		// Triangle
 		-0.5, -0.5, 0.0,
-		 0.5, -0.5, 0.0,
-		 0.0,  0.5, 0.0,
+		0.5, -0.5, 0.0,
+		0.0, 0.5, 0.0,
 	}
 
 	indices := []uint32{0, 1, 2}
@@ -209,10 +230,11 @@ func TestMeshCreation(t *testing.T) {
 }
 
 func TestMeshWithoutIndices(t *testing.T) {
+	glSetup(t)
 	vertices := []float32{
 		-0.5, -0.5, 0.0,
-		 0.5, -0.5, 0.0,
-		 0.0,  0.5, 0.0,
+		0.5, -0.5, 0.0,
+		0.0, 0.5, 0.0,
 	}
 
 	layout := resource.NewVertexLayout().AddFloat(0, 3)
@@ -229,8 +251,9 @@ func TestMeshWithoutIndices(t *testing.T) {
 }
 
 func TestTexture2DCreation(t *testing.T) {
+	glSetup(t)
 	config := resource.DefaultTextureConfig()
-	
+
 	texture, err := resource.NewTexture2D(256, 256, resource.FormatRGBA, config)
 	if err != nil {
 		t.Fatal("Failed to create texture:", err)
@@ -251,8 +274,9 @@ func TestTexture2DCreation(t *testing.T) {
 }
 
 func TestTextureArrayCreation(t *testing.T) {
+	glSetup(t)
 	config := resource.DefaultTextureConfig()
-	
+
 	texArray, err := resource.NewTextureArray(128, 128, 4, resource.FormatRGBA, config)
 	if err != nil {
 		t.Fatal("Failed to create texture array:", err)
@@ -271,8 +295,6 @@ func TestTextureArrayCreation(t *testing.T) {
 func TestTextureManager(t *testing.T) {
 	tm := resource.NewTextureManager()
 
-	// Since we don't have actual image files in tests,
-	// we'll just test the manager structure
 	if tm == nil {
 		t.Fatal("Failed to create texture manager")
 	}
@@ -285,6 +307,7 @@ func TestTextureManager(t *testing.T) {
 }
 
 func TestBufferPool(t *testing.T) {
+	glSetup(t)
 	pool := resource.NewBufferPool()
 
 	// Acquire a buffer
@@ -312,12 +335,12 @@ func TestBufferPool(t *testing.T) {
 		t.Fatal("Failed to acquire reused buffer:", err)
 	}
 
-	// Should reuse buf1 since it's large enough
+	// Should reuse buf1 (same ID, larger than requested)
 	if buf3.ID != buf1.ID {
-		t.Error("Pool should reuse released buffer")
+		t.Error("Should have reused the released buffer")
 	}
 
-	// Clean up
+	// Cleanup
 	pool.Release(buf2)
 	pool.Release(buf3)
 	pool.Clear()

--- a/tests/unit/shader_test.go
+++ b/tests/unit/shader_test.go
@@ -2,6 +2,7 @@ package shader_test
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -13,7 +14,6 @@ import (
 var testWindow *glfw.Window
 
 const (
-	// testVertexShaderSource is a simple vertex shader used across multiple tests
 	testVertexShaderSource = `#version 410 core
 layout(location = 0) in vec3 aPosition;
 void main() {
@@ -21,22 +21,20 @@ void main() {
 }`
 )
 
-// TestMain sets up OpenGL context once for all tests
 func TestMain(m *testing.M) {
-	// Initialize GLFW
+	runtime.LockOSThread()
+
 	if err := glfw.Init(); err != nil {
 		panic("Failed to initialize GLFW: " + err.Error())
 	}
 	defer glfw.Terminate()
 
-	// Configure OpenGL context
 	glfw.WindowHint(glfw.ContextVersionMajor, 4)
 	glfw.WindowHint(glfw.ContextVersionMinor, 1)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
-	glfw.WindowHint(glfw.Visible, glfw.False) // Keep window hidden
+	glfw.WindowHint(glfw.Visible, glfw.False)
 
-	// Create window
 	var err error
 	testWindow, err = glfw.CreateWindow(100, 100, "Test", nil, nil)
 	if err != nil {
@@ -44,19 +42,30 @@ func TestMain(m *testing.M) {
 	}
 	defer testWindow.Destroy()
 
-	// Make context current
 	testWindow.MakeContextCurrent()
 
-	// Initialize OpenGL
 	if err := gl.Init(); err != nil {
 		panic("Failed to initialize OpenGL: " + err.Error())
 	}
 
-	// Run tests
+	glfw.DetachCurrentContext()
+	runtime.UnlockOSThread()
+
 	os.Exit(m.Run())
 }
 
+func glSetup(t *testing.T) {
+	t.Helper()
+	runtime.LockOSThread()
+	testWindow.MakeContextCurrent()
+	t.Cleanup(func() {
+		glfw.DetachCurrentContext()
+		runtime.UnlockOSThread()
+	})
+}
+
 func TestCompileVertexShader(t *testing.T) {
+	glSetup(t)
 	compiledShader, err := shader.CompileShader(testVertexShaderSource, shader.VertexShader)
 	if err != nil {
 		t.Fatal("Failed to compile vertex shader:", err)
@@ -73,6 +82,7 @@ func TestCompileVertexShader(t *testing.T) {
 }
 
 func TestCompileFragmentShader(t *testing.T) {
+	glSetup(t)
 	source := `#version 410 core
 out vec4 fragColor;
 void main() {
@@ -95,6 +105,7 @@ void main() {
 }
 
 func TestCompileInvalidShader(t *testing.T) {
+	glSetup(t)
 	source := `#version 410 core
 invalid syntax here
 `
@@ -106,6 +117,7 @@ invalid syntax here
 }
 
 func TestCreateProgram(t *testing.T) {
+	glSetup(t)
 	fragmentSource := `#version 410 core
 out vec4 fragColor;
 void main() {
@@ -134,14 +146,13 @@ void main() {
 		t.Error("Program ID should not be 0")
 	}
 
-	// Test program validation
 	if err := program.Validate(); err != nil {
-		// Note: Program validation may fail without a VAO bound, which is expected
 		t.Log("Program validation warning:", err)
 	}
 }
 
 func TestGetUniformLocation(t *testing.T) {
+	glSetup(t)
 	vertexSource := `#version 410 core
 layout(location = 0) in vec3 aPosition;
 uniform mat4 uModelViewProjection;
@@ -190,16 +201,14 @@ void main() {
 	}
 }
 
-// TestInputValidation tests the new input validation features
 func TestInputValidation(t *testing.T) {
-	// Test empty shader source
+	glSetup(t)
 	_, err := shader.CompileShader("", shader.VertexShader)
 	if err == nil {
 		t.Error("Expected error for empty shader source")
 	}
 
-	// Test very large shader source (mock the limit)
-	largeSource := strings.Repeat("//comment\n", 100000) // Should be within 1MB limit
+	largeSource := strings.Repeat("//comment\n", 100000)
 	_, err = shader.CompileShader(largeSource, shader.VertexShader)
 	if err == nil {
 		t.Log("Large shader compilation attempted (may fail due to syntax)")
@@ -207,19 +216,17 @@ func TestInputValidation(t *testing.T) {
 }
 
 func TestProgramValidation(t *testing.T) {
-	// Test program creation with no shaders
+	glSetup(t)
 	_, err := shader.CreateProgram()
 	if err == nil {
 		t.Error("Expected error when creating program with no shaders")
 	}
 
-	// Test program creation with nil shader
 	_, err = shader.CreateProgram(nil)
 	if err == nil {
 		t.Error("Expected error when creating program with nil shader")
 	}
 
-	// Test program creation with only vertex shader (missing fragment)
 	vertexShader, err := shader.CompileShader(testVertexShaderSource, shader.VertexShader)
 	if err != nil {
 		t.Fatal("Failed to compile vertex shader:", err)
@@ -233,6 +240,7 @@ func TestProgramValidation(t *testing.T) {
 }
 
 func TestUniformValidation(t *testing.T) {
+	glSetup(t)
 	vertexSource := `#version 410 core
 layout(location = 0) in vec3 aPosition;
 uniform mat4 uMatrix;
@@ -266,7 +274,6 @@ void main() {
 	}
 	defer program.Delete()
 
-	// Test invalid uniform location handling
 	err = program.SetUniform1f(-1, 1.0)
 	if err == nil {
 		t.Error("Expected error for invalid uniform location in SetUniform1f")
@@ -277,7 +284,6 @@ void main() {
 		t.Error("Expected error for invalid uniform location in SetUniform3f")
 	}
 
-	// Test nil matrix
 	err = program.SetUniformMatrix4fv(0, nil)
 	if err == nil {
 		t.Error("Expected error for nil matrix in SetUniformMatrix4fv")


### PR DESCRIPTION
## Summary

- **Fix flaky GL tests** — root cause: Go's test runner runs `TestXxx` functions on a different OS thread than `TestMain`. The OpenGL context was created and made current in `TestMain`, so individual tests sometimes ran on a thread with no active context, causing `glGen*` to silently return 0 (~75% failure rate under llvmpipe).
- **Prepare v0.3.0** — update `CHANGELOG.md` from `Unreleased` to `v0.3.0`.

## Root cause & fix

`TestMain` creates the GLFW window and calls `MakeContextCurrent` + `gl.Init()`. But `m.Run()` schedules test functions on a goroutine that can land on a different OS thread — and GL contexts are thread-local.

The fix adds a `glSetup(t)` helper to each test package:

1. `TestMain` calls `DetachCurrentContext()` + `UnlockOSThread()` after `gl.Init()`, releasing the context.
2. Each test that needs GL calls `glSetup(t)`, which does `LockOSThread()` + `MakeContextCurrent()` and registers a `t.Cleanup` to detach and unlock.

## Test plan

- [x] Verified 30/30 pass locally (was ~25% before the fix)
- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] All three test suites pass: `tests/unit/`, `tests/unit/pipeline/`, `tests/unit/resource/`

## After merge

Create a `v0.3.0` tag + GitHub release from `main` — this makes the updated docs visible on pkg.go.dev.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqByBmvL7k7SgBj7mTaFsS)_